### PR TITLE
Add Elevator CANdi and Pivot CANcoder

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -7,17 +7,20 @@ apriltag_layout = AprilTagFieldLayout.loadField(AprilTagField.k2025Reefscape)
 
 class Constants:
 
-    class MotorIDs:
+    class CanIDs:
+        LEFT_ELEVATOR_TALON = 10
+        RIGHT_ELEVATOR_TALON = 11
+        INTAKE_TALON = 12
+        LEFT_PIVOT_TALON = 13
+        RIGHT_PIVOT_TALON = 14
+        CLIMB_TALON = 15
 
-        LEFT_LIFT_MOTOR = 10
-        RIGHT_LIFT_MOTOR = 11
-        INTAKE_MOTOR = 12
-        LEFT_PIVOT_MOTOR = 13
-        RIGHT_PIVOT_MOTOR = 14
-        CLIMB_MOTOR = 15
+        ELEVATOR_CANDI = 20
+        PIVOT_CANCODER = 21
+
 
     class ClimberConstants:
-        GEAR_RATIO = 15376/135
+        GEAR_RATIO = 15376/45
         GAINS = (Slot0Configs()
             .with_k_p(1.0)
             .with_k_i(0.0)
@@ -28,7 +31,6 @@ class Constants:
         )
 
     class ElevatorConstants:
-
         L1_SCORE_POSITION = 1 # Placeholders
         L2_SCORE_POSITION = 2
         L3_SCORE_POSITION = 3
@@ -52,7 +54,6 @@ class Constants:
         )
 
     class PivotConstants:
-
         STOW_ANGLE = 0
         GROUND_INTAKE_ANGLE = units.degreesToRotations(90)
         FUNNEL_INTAKE_ANGLE = 0
@@ -74,6 +75,7 @@ class Constants:
                  .with_k_a(0.0)
                  .with_gravity_type(GravityTypeValue.ARM_COSINE)
         )
+        CANCODER_OFFSET = 0.0069
 
     class IntakeConstants:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,11 +4,11 @@ robotpy_version = "2025.2.1.3"
 
 robotpy_extras = [
     "apriltag",
-    "commands2",
-    "phoenix6"
+    "commands2"
 ]
 
 # Other pip packages to install
 requires = [
-    "robotpy-pathplannerlib==2025.2.2"
+    "robotpy-pathplannerlib==2025.2.2",
+    "phoenix6==25.2.2"
 ]

--- a/subsystems/climber.py
+++ b/subsystems/climber.py
@@ -28,7 +28,7 @@ class ClimberSubsystem(StateSubsystem):
     def __init__(self) -> None:
         super().__init__("Climber")
 
-        self._climb_motor = TalonFX(Constants.MotorIDs.CLIMB_MOTOR)
+        self._climb_motor = TalonFX(Constants.CanIDs.CLIMB_TALON)
         self._climb_motor.configurator.apply(self._motor_config)
 
         self._climb_request = DutyCycleOut(0)

--- a/subsystems/elevator.py
+++ b/subsystems/elevator.py
@@ -52,7 +52,7 @@ class ElevatorSubsystem(StateSubsystem):
         self._follower_motor.configurator.apply(self._motor_config)
 
         self._candi = CANdi(Constants.CanIDs.ELEVATOR_CANDI)
-        self._candi.configurator.apply(self._candi)
+        self._candi.configurator.apply(self._candi_config)
 
         self._position_request = PositionDutyCycle(0)
         self._brake_request = DutyCycleOut(0)

--- a/subsystems/elevator.py
+++ b/subsystems/elevator.py
@@ -4,11 +4,12 @@ from enum import Enum, auto
 from commands2 import Command
 from commands2.sysid import SysIdRoutine
 from phoenix6 import SignalLogger
-from phoenix6.configs import TalonFXConfiguration, MotorOutputConfigs, FeedbackConfigs
+from phoenix6.configs import TalonFXConfiguration, MotorOutputConfigs, FeedbackConfigs, CANdiConfiguration, QuadratureConfigs, DigitalInputsConfigs
 from phoenix6.configs.config_groups import NeutralModeValue
 from phoenix6.controls import Follower, VoltageOut
 from phoenix6.controls import PositionDutyCycle, DutyCycleOut
-from phoenix6.hardware import TalonFX
+from phoenix6.hardware import CANdi, TalonFX
+from phoenix6.signals import S1CloseStateValue
 from wpilib import DriverStation
 from wpilib.sysid import SysIdRoutineLog
 from wpimath.system.plant import DCMotor
@@ -33,6 +34,8 @@ class ElevatorSubsystem(StateSubsystem):
         L3_ALGAE = auto()
         NET = auto()
 
+    _candi_config = CANdiConfiguration()
+
     _motor_config = (TalonFXConfiguration()
                      .with_slot0(Constants.ElevatorConstants.GAINS)
                      .with_motor_output(MotorOutputConfigs().with_neutral_mode(NeutralModeValue.BRAKE))
@@ -42,11 +45,14 @@ class ElevatorSubsystem(StateSubsystem):
     def __init__(self) -> None:
         super().__init__("Elevator")
 
-        self._master_motor = TalonFX(Constants.MotorIDs.LEFT_LIFT_MOTOR)
+        self._master_motor = TalonFX(Constants.CanIDs.LEFT_ELEVATOR_TALON)
         self._master_motor.configurator.apply(self._motor_config)
 
-        self._follower_motor = TalonFX(Constants.MotorIDs.RIGHT_LIFT_MOTOR)
+        self._follower_motor = TalonFX(Constants.CanIDs.RIGHT_ELEVATOR_TALON)
         self._follower_motor.configurator.apply(self._motor_config)
+
+        self._candi = CANdi(Constants.CanIDs.ELEVATOR_CANDI)
+        self._candi.configurator.apply(self._candi)
 
         self._position_request = PositionDutyCycle(0)
         self._brake_request = DutyCycleOut(0)

--- a/subsystems/intake.py
+++ b/subsystems/intake.py
@@ -31,7 +31,7 @@ class IntakeSubsystem(StateSubsystem):
     def __init__(self) -> None:
         super().__init__("Intake")
 
-        self._intake_motor = TalonFX(Constants.MotorIDs.INTAKE_MOTOR)
+        self._intake_motor = TalonFX(Constants.CanIDs.INTAKE_TALON)
         self._intake_motor.configurator.apply(self._motor_config)
 
         self._velocity_request = VelocityDutyCycle(0)

--- a/subsystems/pivot.py
+++ b/subsystems/pivot.py
@@ -2,12 +2,12 @@ from enum import auto, Enum
 
 from commands2 import Command
 from commands2.sysid import SysIdRoutine
-from phoenix6 import SignalLogger
-from phoenix6.hardware import TalonFX
-from phoenix6.configs import TalonFXConfiguration
-from phoenix6.signals import InvertedValue
+from phoenix6 import SignalLogger, utils
+from phoenix6.hardware import CANcoder, TalonFX
+from phoenix6.configs import TalonFXConfiguration, CANcoderConfiguration, MagnetSensorConfigs
+from phoenix6.signals import InvertedValue, FeedbackSensorSourceValue, SensorDirectionValue
 from phoenix6.controls import PositionDutyCycle, VoltageOut, Follower
-from wpilib import SmartDashboard, DriverStation
+from wpilib import SmartDashboard, DriverStation, RobotController
 from wpilib.sysid import SysIdRoutineLog
 from wpimath.system.plant import DCMotor
 
@@ -18,6 +18,7 @@ class PivotSubsystem(StateSubsystem):
     """
     The PivotSubsystem is responsible for controlling the end effector's current rotation.
     It uses a PositionDutyCycle to quickly transition between set points and is tuned through the use of SysId routines.
+    It also incorporates a fused CANcoder to mitigate backlash through the pivot gearbox, increasing accuracy.
     """
 
     class SubsystemState(Enum):
@@ -31,30 +32,39 @@ class PivotSubsystem(StateSubsystem):
         NET_SCORING = auto()
         PROCESSOR_SCORING = auto()
 
+    _encoder_config = CANcoderConfiguration()
+    _encoder_config.magnet_sensor.with_magnet_offset(Constants.PivotConstants.CANCODER_OFFSET)
+
     _master_config = TalonFXConfiguration()
-    _master_config.feedback.with_rotor_to_sensor_ratio(Constants.PivotConstants.GEAR_RATIO)
+    (_master_config.feedback
+     .with_rotor_to_sensor_ratio(Constants.PivotConstants.GEAR_RATIO)
+     .with_feedback_sensor_source(FeedbackSensorSourceValue.FUSED_CANCODER)
+     .with_feedback_remote_sensor_id(Constants.CanIDs.PIVOT_CANCODER)
+    )
     _master_config.with_slot0(Constants.PivotConstants.GAINS)
 
-    _follower_config = TalonFXConfiguration
+    _follower_config = TalonFXConfiguration()
     _follower_config.feedback.with_rotor_to_sensor_ratio(Constants.PivotConstants.GEAR_RATIO)
     _follower_config.with_slot0(Constants.PivotConstants.GAINS)
-    _follower_config.motor_output = InvertedValue.CLOCKWISE_POSITIVE
+    _follower_config.motor_output.inverted = InvertedValue.CLOCKWISE_POSITIVE
 
     def __init__(self) -> None:
         super().__init__("Pivot")
 
-        self._master_pivot_motor = TalonFX(Constants.MotorIDs.LEFT_PIVOT_MOTOR)
-        self._follower_pivot_motor = TalonFX(Constants.MotorIDs.RIGHT_PIVOT_MOTOR)
+        self._encoder = CANcoder(Constants.CanIDs.PIVOT_CANCODER)
+        self._master_motor = TalonFX(Constants.CanIDs.LEFT_PIVOT_TALON)
+        self._follower_motor = TalonFX(Constants.CanIDs.RIGHT_PIVOT_TALON)
 
-        self._master_pivot_motor.configurator.apply(self._master_config)
-        self._follower_pivot_motor.configurator.apply(self._follower_config)
+        self._encoder.configurator.apply(self._encoder_config)
+        self._master_motor.configurator.apply(self._master_config)
+        self._follower_motor.configurator.apply(self._follower_config)
 
-        self._add_talon_sim_model(self._pivot_motor, DCMotor.krakenX60FOC(2), Constants.PivotConstants.GEAR_RATIO)
+        self._add_talon_sim_model(self._master_motor, DCMotor.krakenX60FOC(2), Constants.PivotConstants.GEAR_RATIO)
 
         self._position_request = PositionDutyCycle(0)
         self._sys_id_request = VoltageOut(0)
 
-        self._follower_motor.set_control(Follower(self._master_pivot_motor.device_id, False))
+        self._follower_motor.set_control(Follower(self._master_motor.device_id, False))
 
         self._sys_id_routine = SysIdRoutine(
             SysIdRoutine.Config(
@@ -63,14 +73,23 @@ class PivotSubsystem(StateSubsystem):
                 )  # Log to .hoot for ease of access
             ),
             SysIdRoutine.Mechanism(
-                lambda output: self._pivot_motor.set_control(self._sys_id_request.with_output(output)),
+                lambda output: self._master_motor.set_control(self._sys_id_request.with_output(output)),
                 lambda log: None,
                 self,
-            ),
+            )
         )
 
     def periodic(self):
-        return super().periodic()
+        super().periodic()
+
+        # Update CANcoder sim state
+        if utils.is_simulation():
+            talon_sim = self._sim_models[0][0]
+            cancoder_sim = self._encoder.sim_state
+
+            cancoder_sim.set_supply_voltage(RobotController.getBatteryVoltage())
+            cancoder_sim.set_raw_position(talon_sim.getAngularPosition() / Constants.PivotConstants.GEAR_RATIO)
+            cancoder_sim.set_velocity(talon_sim.getAngularVelocity() / Constants.PivotConstants.GEAR_RATIO)
 
     def set_desired_state(self, desired_state: SubsystemState) -> None:
 
@@ -98,10 +117,10 @@ class PivotSubsystem(StateSubsystem):
                 self._position_request.position = Constants.PivotConstants.ALGAE_INTAKE_ANGLE
 
         self._subsystem_state = desired_state
-        self._pivot_motor.set_control(self._position_request)
+        self._master_motor.set_control(self._position_request)
 
     def stop(self) -> Command:
-        return self.runOnce(lambda: self._pivot_motor.set_control(self._sys_id_request.with_output(0)))
+        return self.runOnce(lambda: self._master_motor.set_control(self._sys_id_request.with_output(0)))
 
     def sys_id_quasistatic(self, direction: SysIdRoutine.Direction) -> Command:
         return self._sys_id_routine.quasistatic(direction).andThen(self.stop())
@@ -111,4 +130,4 @@ class PivotSubsystem(StateSubsystem):
 
     def get_angle(self) -> float:
         """Returns the current angle of the pivot, in degrees."""
-        return self._pivot_motor.get_position().value * 360
+        return self._master_motor.get_position().value * 360


### PR DESCRIPTION
Updates the Phoenix 6 dependencies and adds both the CANdi and CANcoder into their respective subsystems. We can work Monday on implementing these devices into our periodic code.

CAN Ids are currently placeholders.