### PR TITLE
Ignore hardware limits for intake control request

### DIFF
--- a/subsystems/intake.py
+++ b/subsystems/intake.py
@@ -43,10 +43,13 @@ class IntakeSubsystem(StateSubsystem):
         # TODO: Add beam break sensors to help determine correct state.
         match desired_state:
             case self.SubsystemState.DEFAULT:
+                self._velocity_request.ignore_hardware_limits = False
                 self._velocity_request.velocity = 0
             case self.SubsystemState.INTAKING:
+                self._velocity_request.ignore_hardware_limits = False
                 self._velocity_request.velocity = Constants.IntakeConstants.INTAKE_SPEED
             case self.SubsystemState.OUTPUTTING:
+                self._velocity_request.ignore_hardware_limits = True
                 self._velocity_request.velocity = Constants.IntakeConstants.OUTPUT_SPEED
 
         self._subsystem_state = desired_state

--- a/subsystems/intake.py
+++ b/subsystems/intake.py
@@ -40,7 +40,6 @@ class IntakeSubsystem(StateSubsystem):
         super().periodic()
 
     def set_desired_state(self, desired_state: SubsystemState) -> None:
-        # TODO: Add beam break sensors to help determine correct state.
         match desired_state:
             case self.SubsystemState.DEFAULT:
                 self._velocity_request.ignore_hardware_limits = False

--- a/subsystems/intake.py
+++ b/subsystems/intake.py
@@ -49,7 +49,7 @@ class IntakeSubsystem(StateSubsystem):
                 self._velocity_request.ignore_hardware_limits = False
                 self._velocity_request.velocity = Constants.IntakeConstants.INTAKE_SPEED
             case self.SubsystemState.OUTPUTTING:
-                self._velocity_request.ignore_hardware_limits = True
+                self._velocity_request.ignore_hardware_limits = True # Ignore the beam break stop while scoring coral
                 self._velocity_request.velocity = Constants.IntakeConstants.OUTPUT_SPEED
 
         self._subsystem_state = desired_state


### PR DESCRIPTION
When you score the coral, you must ignore the beam break hardware since it comes out the other side.
But otherwise, it is on so that the intake knows when to stop.