### PR TITLE
Fix Initial State Setting

### DIFF
--- a/subsystems/__init__.py
+++ b/subsystems/__init__.py
@@ -24,11 +24,19 @@ class StateSubsystem(Subsystem, ABC, metaclass=StateSubsystemMeta):
     class SubsystemState(Enum):
         OFF = 0
 
-    def __init__(self, name: str, current_state: SubsystemState=SubsystemState(0)):
+    def __init__(self, name: str, starting_state: SubsystemState):
+        """
+        Initializes all subsystem logging and sets the default state.
+        
+        :param name: Name of the subsystem
+        :type name: str
+        :param starting_state: Starting state of the subsystem
+        :type starting_state:
+        """
         super().__init__()
         self.setName(name.title())
 
-        self._subsystem_state = current_state
+        self._subsystem_state = starting_state
         self._freeze = False
 
         # Create NT folder for organization

--- a/subsystems/climber.py
+++ b/subsystems/climber.py
@@ -29,7 +29,7 @@ class ClimberSubsystem(StateSubsystem):
                      )
 
     def __init__(self) -> None:
-        super().__init__("Climber")
+        super().__init__("Climber", self.SubsystemState.STOP)
 
         self.climbServo = Servo(0)
         self._climb_motor = TalonFX(Constants.CanIDs.CLIMB_TALON)

--- a/subsystems/elevator.py
+++ b/subsystems/elevator.py
@@ -60,7 +60,7 @@ class ElevatorSubsystem(StateSubsystem):
     _limit_switch_config.reverse_limit_autoset_position_enable = True
 
     def __init__(self) -> None:
-        super().__init__("Elevator")
+        super().__init__("Elevator", self.SubsystemState.DEFAULT)
 
         self._master_motor = TalonFX(Constants.CanIDs.LEFT_ELEVATOR_TALON)
         _master_config = self._motor_config

--- a/subsystems/funnel.py
+++ b/subsystems/funnel.py
@@ -27,9 +27,7 @@ class FunnelSubsystem(StateSubsystem):
     _funnel_config.with_motion_magic(MotionMagicConfigs().with_motion_magic_cruise_velocity(Constants.FunnelConstants.CRUISE_VELOCITY).with_motion_magic_acceleration(Constants.FunnelConstants.MM_ACCELERATION))
 
     def __init__(self) -> None:
-        super().__init__("Funnel")
-
-        self._subsystem_state = self.SubsystemState.DOWN
+        super().__init__("Funnel", self.SubsystemState.DOWN)
 
         self._funnel_motor = TalonFX(Constants.CanIDs.FUNNEL_TALON)
 

--- a/subsystems/intake.py
+++ b/subsystems/intake.py
@@ -29,7 +29,7 @@ class IntakeSubsystem(StateSubsystem):
                      )
 
     def __init__(self) -> None:
-        super().__init__("Intake")
+        super().__init__("Intake", self.SubsystemState.DEFAULT)
 
         self._intake_motor = TalonFX(Constants.CanIDs.INTAKE_TALON)
         self._intake_motor.configurator.apply(self._motor_config)

--- a/subsystems/pivot.py
+++ b/subsystems/pivot.py
@@ -61,7 +61,8 @@ class PivotSubsystem(StateSubsystem):
     _follower_config.motor_output.inverted = InvertedValue.CLOCKWISE_POSITIVE
 
     def __init__(self) -> None:
-        super().__init__("Pivot")
+        super().__init__("Pivot", self.SubsystemState.STOW)
+
         self._encoder = CANcoder(Constants.CanIDs.PIVOT_CANCODER)
         self._master_motor = TalonFX(Constants.CanIDs.LEFT_PIVOT_TALON)
         self._follower_motor = TalonFX(Constants.CanIDs.RIGHT_PIVOT_TALON)


### PR DESCRIPTION
Previously, when initialzing subsystems, the state of the subsystem would incorrectly get set to `SubsystemState.OFF` due to the default argument passed inside the `StateSubsystem` class. This fixes the issue by making the starting state of the subsystem a needed argument.