### PR TITLE
Safety Check Rewrite

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -102,7 +102,7 @@ class Constants:
         )
 
         CANCODER_DISCONTINUITY = 0.8
-        CANCODER_OFFSET = 0.4751769375
+        CANCODER_OFFSET = 0.6541
 
         SETPOINT_TOLERANCE = 0.03125
 

--- a/constants.py
+++ b/constants.py
@@ -5,7 +5,7 @@ from robotpy_apriltag import AprilTagField, AprilTagFieldLayout
 
 class Constants:
 
-    apriltag_layout = AprilTagFieldLayout.loadField(AprilTagField.k2025ReefscapeWelded)
+    FIELD_LAYOUT = AprilTagFieldLayout.loadField(AprilTagField.k2025ReefscapeWelded)
 
     class CanIDs:
         LEFT_ELEVATOR_TALON = 10
@@ -70,15 +70,15 @@ class Constants:
         SETPOINT_TOLERANCE = 0.1
 
     class PivotConstants:
-        INSIDE_ELEVATOR_ANGLE = 0.262207 # Used for subsystem collision checking
-        ELEVATOR_PRIORITY_ANGLE = 0.201943 # We move the pivot to this position until the elevator has reached its setpoint.
-        STOW_ANGLE = 0.253174
+        INSIDE_ELEVATOR_ANGLE = 0.2 # Used for subsystem collision checking
+        ELEVATOR_PRIORITY_ANGLE = 0.168 # We move the pivot to this position until the elevator has reached its setpoint.
+        STOW_ANGLE = 0.188
         GROUND_INTAKE_ANGLE = -0.081543
-        FUNNEL_INTAKE_ANGLE = 0.315
-        ALGAE_INTAKE_ANGLE = -0.033
-        HIGH_SCORING_ANGLE =  0.262
-        MID_SCORING_ANGLE = 0.262
-        LOW_SCORING_ANGLE = -0.077
+        FUNNEL_INTAKE_ANGLE = 0.275
+        ALGAE_INTAKE_ANGLE = -0.05
+        HIGH_SCORING_ANGLE =  0.22
+        MID_SCORING_ANGLE = 0.22
+        LOW_SCORING_ANGLE = -0.009
         NET_SCORING_ANGLE = 0.123535
         PROCESSOR_SCORING_ANGLE = 0.004639
         CLIMBER_PRIORITY_ANGLE = 0.201943
@@ -87,22 +87,22 @@ class Constants:
         MAXIMUM_ANGLE = 0.392822
 
         CRUISE_VELOCITY = 3
-        MM_ACCELERATION = 2
+        MM_ACCELERATION = 3
 
         GEAR_RATIO = 961/36
         GAINS = (Slot0Configs()
-                 .with_k_g(0.0)
-                 .with_k_p(60)
+                 .with_k_g(0.27)
+                 .with_k_p(30)
                  .with_k_i(0.0)
-                 .with_k_d(0.0)
-                 .with_k_s(0.0)
-                 .with_k_v(0.0)
-                 .with_k_a(0.0)
+                 .with_k_d(0.25)
+                 .with_k_s(0.19)
+                 .with_k_v(0.2)
+                 .with_k_a(0.18)
                  .with_gravity_type(GravityTypeValue.ARM_COSINE)
         )
 
-        CANCODER_DISCONTINUITY = 0.8
-        CANCODER_OFFSET = 0.6541
+        CANCODER_DISCONTINUITY = 0.5
+        CANCODER_OFFSET = 0.380126953125
 
         SETPOINT_TOLERANCE = 0.03125
 
@@ -157,3 +157,20 @@ class Constants:
 
         SUPPLY_CURRENT = 20
         STATOR_CURRENT = 50
+    
+    class AutoAlignConstants:
+
+        MAX_DISTANCE = 3.6343
+        
+        TRANSLATION_P = 12
+        TRANSLATION_I = 0
+        TRANSLATION_D = 0.1
+        
+        HEADING_P = 2
+        HEADING_I = 0
+        HEADING_D = 0.2
+        
+        HEADING_TOLERANCE = 2
+
+        VELOCITY_DEADBAND = 0.1
+        ROTATIONAL_DEADBAND = 0.02

--- a/robot_container.py
+++ b/robot_container.py
@@ -95,8 +95,8 @@ class RobotContainer:
     @staticmethod
     def _flip_pose_if_needed(pose: Pose2d) -> Pose2d:
         if (DriverStation.getAlliance() or DriverStation.Alliance.kBlue) == DriverStation.Alliance.kRed:
-            flipped_x = Constants.apriltag_layout.getFieldLength() - pose.X()
-            flipped_y = Constants.apriltag_layout.getFieldWidth() - pose.Y()
+            flipped_x = Constants.FIELD_LAYOUT.getFieldLength() - pose.X()
+            flipped_y = Constants.FIELD_LAYOUT.getFieldWidth() - pose.Y()
             flipped_rotation = Rotation2d(pose.rotation().radians()) + Rotation2d.fromDegrees(180)
             return Pose2d(flipped_x, flipped_y, flipped_rotation)
         return pose

--- a/subsystems/superstructure.py
+++ b/subsystems/superstructure.py
@@ -98,8 +98,9 @@ class Superstructure(Subsystem):
         pivot_state = state.get_pivot_state()
         elevator_state = state.get_elevator_state()
 
-        # If the elevator needs to move and the current pivot position travels into the elevator via it's desired setpoint, prioritize the elevator, then the pivot. Ran anytime we have coral.
-        if (((min(self._pivot_old_setpoint, state.get_pivot_position()) < Constants.PivotConstants.INSIDE_ELEVATOR_ANGLE < self.pivot.get_setpoint()) or (max(self._pivot_old_setpoint, state.get_pivot_position()) > Constants.PivotConstants.INSIDE_ELEVATOR_ANGLE > self.pivot.get_setpoint())) and not self.elevator.is_at_setpoint()) or (pivot_state is not self._pivot_old_state and state.has_coral() and not self.elevator.is_at_setpoint()):
+        # If the elevator needs to move, check if the elevator has coral or if the pivot could interfere with the elevator. 
+        if not self.elevator.is_at_setpoint() and (state.has_coral() or 
+                                                   self.pivot.is_in_elevator(min(self._pivot_old_setpoint, state.get_pivot_position()))):
             # Wait for Pivot to leave elevator
             self.pivot.set_desired_state(PivotSubsystem.SubsystemState.AVOID_ELEVATOR)
             self.pivot.freeze()

--- a/subsystems/superstructure.py
+++ b/subsystems/superstructure.py
@@ -100,7 +100,7 @@ class Superstructure(Subsystem):
 
         # If the elevator needs to move, check if the elevator has coral or if the pivot could interfere with the elevator. 
         if not self.elevator.is_at_setpoint() and (state.has_coral() or 
-                                                   self.pivot.is_in_elevator(min(self._pivot_old_setpoint, state.get_pivot_position()))):
+                                                   self.pivot.is_in_elevator(max(self._pivot_old_setpoint, state.get_pivot_position(), self.pivot._state_configs[pivot_state]))):
             # Wait for Pivot to leave elevator
             self.pivot.set_desired_state(PivotSubsystem.SubsystemState.AVOID_ELEVATOR)
             self.pivot.freeze()


### PR DESCRIPTION
In order to activate the safety checks:
    the elevator must be moving, **and** (the pivot must have a coral **or** the pivot is inside the elevator)

This makes sure the pivot (or a coral inside of the intake) doesn't collide with the elevator while changing superstructure states. 
Currently this only solves problems 1&2 on #67 