### PR TITLE
Improved Safety Checks

### DIFF
--- a/subsystems/__init__.py
+++ b/subsystems/__init__.py
@@ -49,6 +49,7 @@ class StateSubsystem(Subsystem, ABC, metaclass=StateSubsystemMeta):
 
         frozen_nt = self._network_table.getBooleanTopic("Frozen")
         self._frozen_pub = frozen_nt.publish()
+        self._frozen_pub.set(self._frozen)
 
         self._sim_models: list[tuple[DCMotorSim, TalonFX]] = []
 

--- a/subsystems/__init__.py
+++ b/subsystems/__init__.py
@@ -37,7 +37,7 @@ class StateSubsystem(Subsystem, ABC, metaclass=StateSubsystemMeta):
         self.setName(name.title())
 
         self._frozen = False
-        self._subsystem_state = None # This allows set_desired_state to succeed
+        self._subsystem_state = None  # This allows set_desired_state to succeed
         self.__starting_state = starting_state
 
         # Create NT folder for organization
@@ -53,7 +53,7 @@ class StateSubsystem(Subsystem, ABC, metaclass=StateSubsystemMeta):
 
         self._sim_models: list[tuple[DCMotorSim, TalonFX]] = []
 
-    def set_desired_state(self, desired_state: SubsystemState) -> bool: # type: ignore
+    def set_desired_state(self, desired_state: SubsystemState) -> bool:  # type: ignore
         """
         Sets the desired state of the subsystem.
         It's recommended to override this function in order to update objects such as control requests.
@@ -77,12 +77,18 @@ class StateSubsystem(Subsystem, ABC, metaclass=StateSubsystemMeta):
             model[0].setInputVoltage(sim.motor_voltage)
             model[0].update(0.02)
 
-            sim.set_raw_rotor_position(units.radiansToRotations(model[0].getAngularPosition())
-                                       * model[0].getGearing())
-            sim.set_rotor_velocity(units.radiansToRotations(model[0].getAngularVelocity())
-                                       * model[0].getGearing())
-            sim.set_rotor_acceleration(units.radiansToRotations(model[0].getAngularAcceleration())
-                                       * model[0].getGearing())
+            sim.set_raw_rotor_position(
+                units.radiansToRotations(model[0].getAngularPosition())
+                * model[0].getGearing()
+                )
+            sim.set_rotor_velocity(
+                units.radiansToRotations(model[0].getAngularVelocity())
+                * model[0].getGearing()
+                )
+            sim.set_rotor_acceleration(
+                units.radiansToRotations(model[0].getAngularAcceleration())
+                * model[0].getGearing()
+                )
 
     def freeze(self) -> None:
         """Prevents new state changes."""
@@ -96,7 +102,7 @@ class StateSubsystem(Subsystem, ABC, metaclass=StateSubsystemMeta):
 
     def is_frozen(self) -> bool:
         return self._frozen
-            
+
     def get_current_state(self) -> SubsystemState | None:
         state = self._subsystem_state
         return state
@@ -108,8 +114,9 @@ class StateSubsystem(Subsystem, ABC, metaclass=StateSubsystemMeta):
     def get_network_table(self) -> NetworkTable:
         return self._network_table
 
-    def _add_talon_sim_model(self, talon: TalonFX, motor: DCMotor, gearing: float, 
-                             moi: float=0.001) -> None:
+    def _add_talon_sim_model(self, talon: TalonFX, motor: DCMotor, gearing: float,
+                             moi: float = 0.001
+                             ) -> None:
         """Creates a DCMotorSim that updates periodically during 
         simulation. This also logs the talon's status signals to Network
         Tables, regardless if simulated.
@@ -135,8 +142,8 @@ class StateSubsystem(Subsystem, ABC, metaclass=StateSubsystemMeta):
                 ),
                 motor
             ),
-            talon)
+             talon)
         )
-    
+
     def set_desired_state_command(self, state: SubsystemState) -> Command:
         return InstantCommand(lambda: self.set_desired_state(state))

--- a/subsystems/elevator.py
+++ b/subsystems/elevator.py
@@ -1,5 +1,5 @@
 import math
-from enum import Enum, auto
+from enum import Enum
 
 from commands2 import Command
 from commands2.sysid import SysIdRoutine
@@ -26,27 +26,15 @@ class ElevatorSubsystem(StateSubsystem):
     """
 
     class SubsystemState(Enum):
-        IDLE = auto()
-        DEFAULT = auto()
-        L1 = auto()
-        L2 = auto()
-        L3 = auto()
-        L4 = auto()
-        L2_ALGAE = auto()
-        L3_ALGAE = auto()
-        NET = auto()
-
-    _state_configs: dict[SubsystemState, float | None] = {
-        SubsystemState.DEFAULT: Constants.ElevatorConstants.DEFAULT_POSITION,
-        SubsystemState.L1: Constants.ElevatorConstants.L1_SCORE_POSITION,
-        SubsystemState.L2: Constants.ElevatorConstants.L2_SCORE_POSITION,
-        SubsystemState.L3: Constants.ElevatorConstants.L3_SCORE_POSITION,
-        SubsystemState.L4: Constants.ElevatorConstants.L4_SCORE_POSITION,
-        SubsystemState.L2_ALGAE: Constants.ElevatorConstants.L2_ALGAE_POSITION,
-        SubsystemState.L3_ALGAE: Constants.ElevatorConstants.L3_ALGAE_POSITION,
-        SubsystemState.NET: Constants.ElevatorConstants.NET_SCORE_POSITION,
-        SubsystemState.IDLE: None,
-    }
+        IDLE = None
+        DEFAULT = Constants.ElevatorConstants.DEFAULT_POSITION
+        L1 = Constants.ElevatorConstants.L1_SCORE_POSITION
+        L2 = Constants.ElevatorConstants.L2_SCORE_POSITION
+        L3 = Constants.ElevatorConstants.L3_SCORE_POSITION
+        L4 = Constants.ElevatorConstants.L4_SCORE_POSITION
+        L2_ALGAE = Constants.ElevatorConstants.L2_ALGAE_POSITION
+        L3_ALGAE = Constants.ElevatorConstants.L3_ALGAE_POSITION
+        NET = Constants.ElevatorConstants.NET_SCORE_POSITION
 
     _candi_config = CANdiConfiguration()
 
@@ -105,7 +93,6 @@ class ElevatorSubsystem(StateSubsystem):
 
         self._add_talon_sim_model(self._master_motor, DCMotor.krakenX60FOC(2), Constants.ElevatorConstants.GEAR_RATIO)
 
-        self._at_setpoint_debounce = Debouncer(0.1, Debouncer.DebounceType.kRising)
         self._at_setpoint = True
 
         self._master_motor.set_position(Constants.ElevatorConstants.DEFAULT_POSITION)
@@ -129,14 +116,14 @@ class ElevatorSubsystem(StateSubsystem):
         latency_compensated_position = BaseStatusSignal.get_latency_compensated_value(
             self._master_motor.get_position(), self._master_motor.get_velocity()
         )
-        self._at_setpoint = self._at_setpoint_debounce.calculate(abs(latency_compensated_position - self._position_request.position) <= Constants.ElevatorConstants.SETPOINT_TOLERANCE)
+        self._at_setpoint = abs(latency_compensated_position - self._position_request.position) <= Constants.ElevatorConstants.SETPOINT_TOLERANCE
         self.get_network_table().getEntry("At Setpoint").setBoolean(self._at_setpoint)
 
     def set_desired_state(self, desired_state: SubsystemState) -> None:
         if not super().set_desired_state(desired_state):
             return
 
-        position = self._state_configs.get(desired_state, None)
+        position = desired_state.value
 
         if position is None:
             self._brake_request.position = self._master_motor.get_position().value
@@ -151,6 +138,13 @@ class ElevatorSubsystem(StateSubsystem):
             self._master_motor.set_control(self._position_request)
 
     def is_at_setpoint(self) -> bool:
+        if self._subsystem_state is self.SubsystemState.IDLE:
+            return False
+        latency_compensated_position = BaseStatusSignal.get_latency_compensated_value(
+            self._master_motor.get_position(), self._master_motor.get_velocity()
+        )
+        self._at_setpoint = abs(latency_compensated_position - self._position_request.position) <= Constants.ElevatorConstants.SETPOINT_TOLERANCE
+        self.get_network_table().getEntry("At Setpoint").setBoolean(self._at_setpoint)
         return self._at_setpoint
 
     def stop(self) -> Command:

--- a/subsystems/elevator.py
+++ b/subsystems/elevator.py
@@ -10,7 +10,6 @@ from phoenix6.controls import Follower, VoltageOut, DynamicMotionMagicVoltage
 from phoenix6.hardware import CANdi, TalonFX
 from phoenix6.signals import ForwardLimitSourceValue
 from wpilib.sysid import SysIdRoutineLog
-from wpimath.filter import Debouncer
 from wpimath.system.plant import DCMotor
 
 from constants import Constants
@@ -42,24 +41,25 @@ class ElevatorSubsystem(StateSubsystem):
                      .with_slot0(Constants.ElevatorConstants.GAINS)
                      .with_motor_output(MotorOutputConfigs().with_neutral_mode(NeutralModeValue.BRAKE).with_inverted(InvertedValue.CLOCKWISE_POSITIVE))
                      .with_feedback(FeedbackConfigs().with_sensor_to_mechanism_ratio(Constants.ElevatorConstants.GEAR_RATIO))
-                     .with_motion_magic(MotionMagicConfigs()
-                                        .with_motion_magic_acceleration(Constants.ElevatorConstants.MM_DOWNWARD_ACCELERATION)
-                                        .with_motion_magic_cruise_velocity(Constants.ElevatorConstants.CRUISE_VELOCITY)
-                                        # .with_motion_magic_expo_k_v(Constants.ElevatorConstants.EXPO_K_V)
-                                        # .with_motion_magic_expo_k_a(Constants.ElevatorConstants.EXPO_K_A)
-                                        )
+                     .with_motion_magic(
+        MotionMagicConfigs()
+        .with_motion_magic_acceleration(Constants.ElevatorConstants.MM_DOWNWARD_ACCELERATION)
+        .with_motion_magic_cruise_velocity(Constants.ElevatorConstants.CRUISE_VELOCITY)
+        # .with_motion_magic_expo_k_v(Constants.ElevatorConstants.EXPO_K_V)
+        # .with_motion_magic_expo_k_a(Constants.ElevatorConstants.EXPO_K_A)
+        )
                      )
 
     # Limit switch config (separate since it's only applied to the master motor)
     ### NOTE: Flip positions when inverting motor output
     _limit_switch_config = HardwareLimitSwitchConfigs()
     _limit_switch_config.forward_limit_remote_sensor_id = Constants.CanIDs.ELEVATOR_CANDI
-    _limit_switch_config.forward_limit_source = ForwardLimitSourceValue.REMOTE_CANDIS1 # Top Limit Switch
+    _limit_switch_config.forward_limit_source = ForwardLimitSourceValue.REMOTE_CANDIS1  # Top Limit Switch
     _limit_switch_config.forward_limit_autoset_position_value = Constants.ElevatorConstants.ELEVATOR_MAX
     _limit_switch_config.forward_limit_autoset_position_enable = False
 
     _limit_switch_config.reverse_limit_remote_sensor_id = Constants.CanIDs.ELEVATOR_CANDI
-    _limit_switch_config.reverse_limit_source = ForwardLimitSourceValue.REMOTE_CANDIS2 # Bottom Limit Switch
+    _limit_switch_config.reverse_limit_source = ForwardLimitSourceValue.REMOTE_CANDIS2  # Bottom Limit Switch
     _limit_switch_config.reverse_limit_autoset_position_value = Constants.ElevatorConstants.DEFAULT_POSITION
     _limit_switch_config.reverse_limit_autoset_position_enable = True
 

--- a/subsystems/pivot.py
+++ b/subsystems/pivot.py
@@ -25,35 +25,19 @@ class PivotSubsystem(StateSubsystem):
     """
 
     class SubsystemState(Enum):
-        IDLE = auto()
-        AVOID_ELEVATOR = auto()
-        STOW = auto()
-        GROUND_INTAKE = auto()
-        FUNNEL_INTAKE = auto()
-        ALGAE_INTAKE = auto()
-        HIGH_SCORING = auto()
-        L3_CORAL = auto()
-        L2_CORAL = auto()
-        LOW_SCORING = auto()
-        NET_SCORING = auto()
-        PROCESSOR_SCORING = auto()
-        AVOID_CLIMBER = auto()
-
-    _state_configs: dict[SubsystemState, float | None] = {
-        SubsystemState.IDLE: None,
-        SubsystemState.AVOID_ELEVATOR: Constants.PivotConstants.ELEVATOR_PRIORITY_ANGLE,
-        SubsystemState.STOW: Constants.PivotConstants.STOW_ANGLE,
-        SubsystemState.GROUND_INTAKE: Constants.PivotConstants.GROUND_INTAKE_ANGLE,
-        SubsystemState.FUNNEL_INTAKE: Constants.PivotConstants.FUNNEL_INTAKE_ANGLE,
-        SubsystemState.ALGAE_INTAKE: Constants.PivotConstants.ALGAE_INTAKE_ANGLE,
-        SubsystemState.HIGH_SCORING: Constants.PivotConstants.HIGH_SCORING_ANGLE,
-        SubsystemState.L3_CORAL: Constants.PivotConstants.MID_SCORING_ANGLE,
-        SubsystemState.L2_CORAL: Constants.PivotConstants.MID_SCORING_ANGLE,
-        SubsystemState.LOW_SCORING: Constants.PivotConstants.LOW_SCORING_ANGLE,
-        SubsystemState.NET_SCORING: Constants.PivotConstants.NET_SCORING_ANGLE,
-        SubsystemState.PROCESSOR_SCORING: Constants.PivotConstants.PROCESSOR_SCORING_ANGLE,
-        SubsystemState.AVOID_CLIMBER: Constants.PivotConstants.CLIMBER_PRIORITY_ANGLE
-    }
+        IDLE = None
+        AVOID_ELEVATOR = Constants.PivotConstants.ELEVATOR_PRIORITY_ANGLE
+        STOW = Constants.PivotConstants.STOW_ANGLE
+        GROUND_INTAKE = Constants.PivotConstants.GROUND_INTAKE_ANGLE
+        FUNNEL_INTAKE = Constants.PivotConstants.FUNNEL_INTAKE_ANGLE
+        ALGAE_INTAKE = Constants.PivotConstants.ALGAE_INTAKE_ANGLE
+        HIGH_SCORING = Constants.PivotConstants.HIGH_SCORING_ANGLE
+        L3_CORAL = Constants.PivotConstants.MID_SCORING_ANGLE
+        L2_CORAL = Constants.PivotConstants.MID_SCORING_ANGLE
+        LOW_SCORING = Constants.PivotConstants.LOW_SCORING_ANGLE
+        NET_SCORING = Constants.PivotConstants.NET_SCORING_ANGLE
+        PROCESSOR_SCORING = Constants.PivotConstants.PROCESSOR_SCORING_ANGLE
+        AVOID_CLIMBER = Constants.PivotConstants.CLIMBER_PRIORITY_ANGLE
 
     _encoder_config = CANcoderConfiguration()
     (
@@ -143,7 +127,7 @@ class PivotSubsystem(StateSubsystem):
         if not super().set_desired_state(desired_state):
             return
 
-        position = self._state_configs.get(desired_state, None)
+        position = desired_state.value
         if position is None:
             self._master_motor.set_control(self._brake_request)
             return

--- a/subsystems/pivot.py
+++ b/subsystems/pivot.py
@@ -1,4 +1,4 @@
-from enum import auto, Enum
+from enum import Enum
 
 from commands2 import Command
 from commands2.sysid import SysIdRoutine
@@ -6,9 +6,9 @@ from phoenix6 import SignalLogger, utils, BaseStatusSignal
 from phoenix6.configs import TalonFXConfiguration, CANcoderConfiguration, MotionMagicConfigs
 from phoenix6.controls import VoltageOut, Follower, MotionMagicVoltage
 from phoenix6.hardware import CANcoder, TalonFX
-from phoenix6.signals import InvertedValue, FeedbackSensorSourceValue, NeutralModeValue, ForwardLimitValue
+from phoenix6.signals import InvertedValue, FeedbackSensorSourceValue, NeutralModeValue
 from phoenix6.sim import ChassisReference
-from wpilib import DriverStation, RobotBase, RobotController
+from wpilib import RobotBase, RobotController
 from wpilib.sysid import SysIdRoutineLog
 from wpimath.filter import Debouncer
 from wpimath.system.plant import DCMotor
@@ -51,12 +51,14 @@ class PivotSubsystem(StateSubsystem):
      .with_rotor_to_sensor_ratio(Constants.PivotConstants.GEAR_RATIO)
      .with_feedback_sensor_source(FeedbackSensorSourceValue.REMOTE_CANCODER)
      .with_feedback_remote_sensor_id(Constants.CanIDs.PIVOT_CANCODER)
-    )
+     )
     _master_config.motor_output.inverted = InvertedValue.CLOCKWISE_POSITIVE
     _master_config.motor_output.neutral_mode = NeutralModeValue.BRAKE
 
     _master_config.with_slot0(Constants.PivotConstants.GAINS)
-    _master_config.with_motion_magic(MotionMagicConfigs().with_motion_magic_cruise_velocity(Constants.PivotConstants.CRUISE_VELOCITY).with_motion_magic_acceleration(Constants.PivotConstants.MM_ACCELERATION))
+    _master_config.with_motion_magic(
+        MotionMagicConfigs().with_motion_magic_cruise_velocity(Constants.PivotConstants.CRUISE_VELOCITY).with_motion_magic_acceleration(Constants.PivotConstants.MM_ACCELERATION)
+    )
 
     _follower_config = TalonFXConfiguration()
     _follower_config.feedback.with_rotor_to_sensor_ratio(Constants.PivotConstants.GEAR_RATIO)
@@ -122,7 +124,7 @@ class PivotSubsystem(StateSubsystem):
             cancoder_sim.set_supply_voltage(RobotController.getBatteryVoltage())
             cancoder_sim.set_raw_position(talon_sim.getAngularPosition() / Constants.PivotConstants.GEAR_RATIO)
             cancoder_sim.set_velocity(talon_sim.getAngularVelocity() / Constants.PivotConstants.GEAR_RATIO)
-            
+
     def set_desired_state(self, desired_state: SubsystemState) -> None:
         if not super().set_desired_state(desired_state):
             return
@@ -142,7 +144,7 @@ class PivotSubsystem(StateSubsystem):
         if not position:
             position = self._master_motor.get_position(True).value
         return position >= Constants.PivotConstants.INSIDE_ELEVATOR_ANGLE
-    
+
     def get_setpoint(self) -> float:
         return self._position_request.position
 

--- a/subsystems/superstructure.py
+++ b/subsystems/superstructure.py
@@ -4,8 +4,9 @@ from typing import Optional
 from commands2 import Command, Subsystem, cmd
 from ntcore import NetworkTableInstance
 from phoenix6 import utils
-from wpilib import DriverStation, Mechanism2d, Color8Bit
+from wpilib import DriverStation, Mechanism2d, Color8Bit, SmartDashboard
 
+from constants import Constants
 from subsystems.elevator import ElevatorSubsystem
 from subsystems.funnel import FunnelSubsystem
 from subsystems.pivot import PivotSubsystem
@@ -79,50 +80,29 @@ class Superstructure(Subsystem):
         self._goal = self.Goal.DEFAULT
         self.set_goal_command(self._goal)
 
-        self._elevator_old_state = self.elevator.get_current_state()
-        self._pivot_old_state = self.pivot.get_current_state()
-        self._pivot_old_setpoint = self.pivot.get_setpoint()
-
-        self._current_goal_pub = NetworkTableInstance.getDefault().getTable("Superstructure").getStringTopic("Current Goal").publish()
+        table = NetworkTableInstance.getDefault().getTable("Superstructure")
+        self._current_goal_pub = table.getStringTopic("Current Goal").publish()
 
         if utils.is_simulation():
             self._superstructure_mechanism = Mechanism2d(1, 5, Color8Bit(0, 0, 105))
             self._superstructure_root = self._superstructure_mechanism.getRoot("Root", 1 / 2, 0.125)
             self._elevator_mech = self._superstructure_root.appendLigament("Elevator", 0.2794, 90, 5, Color8Bit(194, 194, 194))
             self._pivot_mech = self._elevator_mech.appendLigament("Pivot", 0.635, 90, 4, Color8Bit(19, 122, 127))
+            SmartDashboard.putData("Superstructure Mechanism", self._superstructure_mechanism)
 
     def periodic(self):
         if DriverStation.isDisabled():
             return
 
-        pivot_state = self.pivot.get_current_state()
-        elevator_state = self.elevator.get_current_state()
-
-        # If the elevator needs to move, check if the elevator has coral or if the pivot could interfere with the elevator. 
-        if not self.elevator.is_at_setpoint():
-            # Wait for Pivot to leave elevator
-            self.pivot.set_desired_state(PivotSubsystem.SubsystemState.AVOID_ELEVATOR)
-            self.pivot.freeze()
-            if self.pivot.is_in_elevator():
-                self.elevator.set_desired_state(ElevatorSubsystem.SubsystemState.IDLE)
-                self.elevator.freeze()
-
         # Unfreeze subsystems if safe
-        if not self.pivot.is_in_elevator() and pivot_state is PivotSubsystem.SubsystemState.AVOID_ELEVATOR and elevator_state is ElevatorSubsystem.SubsystemState.IDLE:
+        if self.elevator.is_frozen() and not self.pivot.is_in_elevator():
             self.elevator.unfreeze()
-            self.elevator.set_desired_state(self._elevator_old_state)
+            self.elevator.set_desired_state(self._desired_elevator_state)
 
-        if self.elevator.is_at_setpoint() and pivot_state is PivotSubsystem.SubsystemState.AVOID_ELEVATOR:
+        # If the elevator reaches its setpoint or the pivot is outside the elevator and can reach its target safely, unfreeze the pivot
+        if self.pivot.get_current_state() is PivotSubsystem.SubsystemState.AVOID_ELEVATOR and not self.pivot.is_in_elevator() and (self.elevator.is_at_setpoint() or self._desired_pivot_state.value < Constants.PivotConstants.INSIDE_ELEVATOR_ANGLE): #(not self.pivot.is_in_elevator() and self._desired_pivot_state.value < Constants.PivotConstants.INSIDE_ELEVATOR_ANGLE)):
             self.pivot.unfreeze()
-            self.pivot.set_desired_state(self._pivot_old_state)
-
-        # Update old states only when necessary
-        if pivot_state is not PivotSubsystem.SubsystemState.AVOID_ELEVATOR:
-            self._pivot_old_state = pivot_state
-            self._pivot_old_setpoint = self.pivot.get_setpoint()
-
-        if elevator_state is not ElevatorSubsystem.SubsystemState.IDLE:
-            self._elevator_old_state = elevator_state
+            self.pivot.set_desired_state(self._desired_pivot_state)
 
     def simulationPeriodic(self) -> None:
         self._elevator_mech.setLength(self.elevator.get_height())
@@ -132,14 +112,33 @@ class Superstructure(Subsystem):
         self._goal = goal
 
         pivot_state, elevator_state, funnel_state = self._goal_to_states.get(goal, (None, None, None))
+
+        safety_checks = self._should_enable_safety_checks(pivot_state)
         if pivot_state:
-            self.pivot.set_desired_state(pivot_state)
+            self._desired_pivot_state = pivot_state
+            if safety_checks:
+                self.pivot.set_desired_state(PivotSubsystem.SubsystemState.AVOID_ELEVATOR)
+                self.pivot.freeze()
+            else:
+                self.pivot.set_desired_state(pivot_state)
         if elevator_state:
-            self.elevator.set_desired_state(elevator_state)
+            self._desired_elevator_state = elevator_state
+            if pivot_state and safety_checks:
+                self.elevator.set_desired_state(ElevatorSubsystem.SubsystemState.IDLE)
+                self.elevator.freeze()
+            else:
+                self.elevator.set_desired_state(elevator_state)
         if funnel_state:
             self.funnel.set_desired_state(funnel_state)
 
         self._current_goal_pub.set(goal.name)
+
+    def _should_enable_safety_checks(self, pivot_state: PivotSubsystem.SubsystemState) -> bool:
+        """Safety checks are always activated, unless we're already outside the elevator and the new state is also outside the elevator."""
+        return not (
+            self.pivot.get_current_state().value < Constants.PivotConstants.INSIDE_ELEVATOR_ANGLE
+            and pivot_state.value < Constants.PivotConstants.INSIDE_ELEVATOR_ANGLE
+        )
 
     def set_goal_command(self, goal: Goal) -> Command:
         """

--- a/subsystems/superstructure.py
+++ b/subsystems/superstructure.py
@@ -29,18 +29,18 @@ class Superstructure(Subsystem):
         L3_ALGAE = auto()
         PROCESSOR = auto()
         NET = auto()
-        
+
         FUNNEL = auto()
         FLOOR = auto()
         CLIMBING = auto()
 
     # Map each goal to each subsystem state to reduce code complexity
     _goal_to_states: dict[Goal,
-            tuple[
-                Optional[PivotSubsystem.SubsystemState],
-                Optional[ElevatorSubsystem.SubsystemState],
-                Optional[FunnelSubsystem.SubsystemState]
-            ]] = {
+    tuple[
+        Optional[PivotSubsystem.SubsystemState],
+        Optional[ElevatorSubsystem.SubsystemState],
+        Optional[FunnelSubsystem.SubsystemState]
+    ]] = {
         Goal.DEFAULT: (PivotSubsystem.SubsystemState.STOW, ElevatorSubsystem.SubsystemState.DEFAULT, FunnelSubsystem.SubsystemState.DOWN),
         Goal.L4_CORAL: (PivotSubsystem.SubsystemState.HIGH_SCORING, ElevatorSubsystem.SubsystemState.L4, FunnelSubsystem.SubsystemState.DOWN),
         Goal.L3_CORAL: (PivotSubsystem.SubsystemState.L3_CORAL, ElevatorSubsystem.SubsystemState.L3, FunnelSubsystem.SubsystemState.DOWN),
@@ -54,7 +54,7 @@ class Superstructure(Subsystem):
         Goal.FLOOR: (PivotSubsystem.SubsystemState.GROUND_INTAKE, ElevatorSubsystem.SubsystemState.DEFAULT, FunnelSubsystem.SubsystemState.DOWN),
         Goal.CLIMBING: (PivotSubsystem.SubsystemState.AVOID_CLIMBER, ElevatorSubsystem.SubsystemState.DEFAULT, FunnelSubsystem.SubsystemState.DOWN)
     }
-        
+
     def __init__(self, drivetrain: SwerveSubsystem, pivot: PivotSubsystem, elevator: ElevatorSubsystem, funnel: FunnelSubsystem, vision: VisionSubsystem) -> None:
         """
         Constructs the superstructure using instance of each subsystem.
@@ -100,7 +100,8 @@ class Superstructure(Subsystem):
             self.elevator.set_desired_state(self._desired_elevator_state)
 
         # If the elevator reaches its setpoint or the pivot is outside the elevator and can reach its target safely, unfreeze the pivot
-        if self.pivot.get_current_state() is PivotSubsystem.SubsystemState.AVOID_ELEVATOR and not self.pivot.is_in_elevator() and (self.elevator.is_at_setpoint() or self._desired_pivot_state.value < Constants.PivotConstants.INSIDE_ELEVATOR_ANGLE): #(not self.pivot.is_in_elevator() and self._desired_pivot_state.value < Constants.PivotConstants.INSIDE_ELEVATOR_ANGLE)):
+        if self.pivot.get_current_state() is PivotSubsystem.SubsystemState.AVOID_ELEVATOR and not self.pivot.is_in_elevator() and (
+                self.elevator.is_at_setpoint() or self._desired_pivot_state.value < Constants.PivotConstants.INSIDE_ELEVATOR_ANGLE):
             self.pivot.unfreeze()
             self.pivot.set_desired_state(self._desired_pivot_state)
 
@@ -136,8 +137,8 @@ class Superstructure(Subsystem):
     def _should_enable_safety_checks(self, pivot_state: PivotSubsystem.SubsystemState) -> bool:
         """Safety checks are always activated, unless we're already outside the elevator and the new state is also outside the elevator."""
         return not (
-            self.pivot.get_current_state().value < Constants.PivotConstants.INSIDE_ELEVATOR_ANGLE
-            and pivot_state.value < Constants.PivotConstants.INSIDE_ELEVATOR_ANGLE
+                self.pivot.get_current_state().value < Constants.PivotConstants.INSIDE_ELEVATOR_ANGLE
+                and pivot_state.value < Constants.PivotConstants.INSIDE_ELEVATOR_ANGLE
         )
 
     def set_goal_command(self, goal: Goal) -> Command:


### PR DESCRIPTION
- Safety checks are now enabled when the Superstructure goal changes, not in periodic. This should reduce the overall time for the safety checks to start
- Safety checks no longer activate when the pivot's current setpoint and the new desired setpoint are outside of the elevator
- The pivot safety check can now end prematurely once exiting the elevator (provided the desired setpoint is outside the elevator)
- Superstructure mechanism is now logged in simulation
- StateSubsystems now publish their frozen value when initialized
- Pivot and Elevators no longer have `_state_config` dictionaries and instead have each state enum assigned to the corresponding position. This was to reduce code clutter
- IntelliJ code cleanup