### PR TITLE
Robustify Vision Measurements

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -18,6 +18,8 @@ class Constants:
         ELEVATOR_CANDI = 20
         PIVOT_CANCODER = 21
 
+        INTAKE_CANRANGE = 23
+
     class ClimberConstants:
         GEAR_RATIO = 61504/189
         GAINS = (Slot0Configs()

--- a/deploy/main-layout.json
+++ b/deploy/main-layout.json
@@ -73,13 +73,26 @@
             "title": "limelight-front",
             "x": 896.0,
             "y": 0.0,
-            "width": 512.0,
-            "height": 384.0,
+            "width": 640.0,
+            "height": 512.0,
             "type": "Camera Stream",
             "properties": {
               "topic": "/CameraPublisher/limelight-front",
               "period": 0.06,
               "rotation_turns": 0
+            }
+          },
+          {
+            "title": "USB Camera 0",
+            "x": 256.0,
+            "y": 128.0,
+            "width": 640.0,
+            "height": 512.0,
+            "type": "Camera Stream",
+            "properties": {
+              "topic": "/CameraPublisher/USB Camera 0",
+              "period": 0.06,
+              "rotation_turns": 2
             }
           }
         ]
@@ -120,14 +133,14 @@
             }
           },
           {
-            "title": "limelight-back",
+            "title": "USB Camera 0",
             "x": 0.0,
             "y": 0.0,
             "width": 384.0,
             "height": 384.0,
             "type": "Camera Stream",
             "properties": {
-              "topic": "/CameraPublisher/limelight-back",
+              "topic": "/CameraPublisher/USB Camera 0",
               "period": 0.06,
               "rotation_turns": 0
             }

--- a/deploy/pathplanner/autos/The 'We're Playing with 9450 and 2390' Auto.auto
+++ b/deploy/pathplanner/autos/The 'We're Playing with 9450 and 2390' Auto.auto
@@ -1,0 +1,56 @@
+{
+  "version": "2025.0",
+  "command": {
+    "type": "sequential",
+    "data": {
+      "commands": [
+        {
+          "type": "wait",
+          "data": {
+            "waitTime": 3.5
+          }
+        },
+        {
+          "type": "path",
+          "data": {
+            "pathName": "Center to Coral H"
+          }
+        },
+        {
+          "type": "sequential",
+          "data": {
+            "commands": [
+              {
+                "type": "named",
+                "data": {
+                  "name": "Coral Output"
+                }
+              },
+              {
+                "type": "wait",
+                "data": {
+                  "waitTime": 0.3
+                }
+              },
+              {
+                "type": "named",
+                "data": {
+                  "name": "Hold"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "path",
+          "data": {
+            "pathName": "Coral H Back"
+          }
+        }
+      ]
+    }
+  },
+  "resetOdom": false,
+  "folder": null,
+  "choreoAuto": false
+}

--- a/deploy/pathplanner/paths/Center to Coral H.path
+++ b/deploy/pathplanner/paths/Center to Coral H.path
@@ -1,0 +1,66 @@
+{
+  "version": "2025.0",
+  "waypoints": [
+    {
+      "anchor": {
+        "x": 8.0071875,
+        "y": 4.049928977272727
+      },
+      "prevControl": null,
+      "nextControl": {
+        "x": 7.007187500000001,
+        "y": 4.049928977272727
+      },
+      "isLocked": false,
+      "linkedName": "Center"
+    },
+    {
+      "anchor": {
+        "x": 5.8,
+        "y": 4.18953125
+      },
+      "prevControl": {
+        "x": 7.3,
+        "y": 4.18953125
+      },
+      "nextControl": null,
+      "isLocked": false,
+      "linkedName": "Coral H"
+    }
+  ],
+  "rotationTargets": [],
+  "constraintZones": [],
+  "pointTowardsZones": [],
+  "eventMarkers": [
+    {
+      "name": "L4 Coral",
+      "waypointRelativePos": 0,
+      "endWaypointRelativePos": null,
+      "command": {
+        "type": "named",
+        "data": {
+          "name": "L4 Coral"
+        }
+      }
+    }
+  ],
+  "globalConstraints": {
+    "maxVelocity": 1.0,
+    "maxAcceleration": 1.0,
+    "maxAngularVelocity": 720.0,
+    "maxAngularAcceleration": 1600.0,
+    "nominalVoltage": 12.0,
+    "unlimited": false
+  },
+  "goalEndState": {
+    "velocity": 0,
+    "rotation": 180.0
+  },
+  "reversed": false,
+  "folder": "Blind",
+  "idealStartingState": {
+    "velocity": 0,
+    "rotation": 180.0
+  },
+  "useDefaultConstraints": false
+}

--- a/deploy/pathplanner/paths/Coral H Back.path
+++ b/deploy/pathplanner/paths/Coral H Back.path
@@ -1,0 +1,66 @@
+{
+  "version": "2025.0",
+  "waypoints": [
+    {
+      "anchor": {
+        "x": 5.8,
+        "y": 4.18953125
+      },
+      "prevControl": null,
+      "nextControl": {
+        "x": 6.05,
+        "y": 4.18953125
+      },
+      "isLocked": false,
+      "linkedName": "Coral H"
+    },
+    {
+      "anchor": {
+        "x": 6.351903409090909,
+        "y": 4.18953125
+      },
+      "prevControl": {
+        "x": 6.101903409090909,
+        "y": 4.18953125
+      },
+      "nextControl": null,
+      "isLocked": false,
+      "linkedName": null
+    }
+  ],
+  "rotationTargets": [],
+  "constraintZones": [],
+  "pointTowardsZones": [],
+  "eventMarkers": [
+    {
+      "name": "Default",
+      "waypointRelativePos": 0.03599550056242728,
+      "endWaypointRelativePos": null,
+      "command": {
+        "type": "named",
+        "data": {
+          "name": "Default"
+        }
+      }
+    }
+  ],
+  "globalConstraints": {
+    "maxVelocity": 1.0,
+    "maxAcceleration": 1.0,
+    "maxAngularVelocity": 720.0,
+    "maxAngularAcceleration": 1600.0,
+    "nominalVoltage": 12.0,
+    "unlimited": false
+  },
+  "goalEndState": {
+    "velocity": 0,
+    "rotation": 180.0
+  },
+  "reversed": false,
+  "folder": "Blind",
+  "idealStartingState": {
+    "velocity": 0,
+    "rotation": 180.0
+  },
+  "useDefaultConstraints": false
+}

--- a/deploy/pathplanner/paths/Coral H to Right Funnel.path
+++ b/deploy/pathplanner/paths/Coral H to Right Funnel.path
@@ -1,0 +1,116 @@
+{
+  "version": "2025.0",
+  "waypoints": [
+    {
+      "anchor": {
+        "x": 5.8,
+        "y": 4.18953125
+      },
+      "prevControl": null,
+      "nextControl": {
+        "x": 6.663959495892885,
+        "y": 4.5215306236769
+      },
+      "isLocked": false,
+      "linkedName": "Coral H"
+    },
+    {
+      "anchor": {
+        "x": 7.388948863636363,
+        "y": 3.411747159090909
+      },
+      "prevControl": {
+        "x": 6.974266997342166,
+        "y": 3.909501311060554
+      },
+      "nextControl": {
+        "x": 7.793637170263179,
+        "y": 2.9259885541217874
+      },
+      "isLocked": false,
+      "linkedName": null
+    },
+    {
+      "anchor": {
+        "x": 7.269289772727273,
+        "y": 1.4473437499999988
+      },
+      "prevControl": {
+        "x": 7.710909690415083,
+        "y": 2.100377798065277
+      },
+      "nextControl": {
+        "x": 6.8016894969212975,
+        "y": 0.7558919183326582
+      },
+      "isLocked": false,
+      "linkedName": null
+    },
+    {
+      "anchor": {
+        "x": 4.547045454545454,
+        "y": 0.9687073863636351
+      },
+      "prevControl": {
+        "x": 6.264716023982128,
+        "y": 0.9933026641948172
+      },
+      "nextControl": {
+        "x": 3.859778940945893,
+        "y": 0.9588664359818673
+      },
+      "isLocked": false,
+      "linkedName": null
+    },
+    {
+      "anchor": {
+        "x": 1.6153977272727271,
+        "y": 0.729
+      },
+      "prevControl": {
+        "x": 1.8926508599444944,
+        "y": 0.7042521997684971
+      },
+      "nextControl": null,
+      "isLocked": false,
+      "linkedName": null
+    }
+  ],
+  "rotationTargets": [],
+  "constraintZones": [
+    {
+      "name": "Elevator Up",
+      "minWaypointRelativePos": 0,
+      "maxWaypointRelativePos": 2.0,
+      "constraints": {
+        "maxVelocity": 2.75,
+        "maxAcceleration": 2.25,
+        "maxAngularVelocity": 720.0,
+        "maxAngularAcceleration": 1600.0,
+        "nominalVoltage": 12.0,
+        "unlimited": false
+      }
+    }
+  ],
+  "pointTowardsZones": [],
+  "eventMarkers": [],
+  "globalConstraints": {
+    "maxVelocity": 4.0,
+    "maxAcceleration": 4.5,
+    "maxAngularVelocity": 720.0,
+    "maxAngularAcceleration": 1600.0,
+    "nominalVoltage": 12.0,
+    "unlimited": false
+  },
+  "goalEndState": {
+    "velocity": 0,
+    "rotation": 54.0
+  },
+  "reversed": false,
+  "folder": "Blind",
+  "idealStartingState": {
+    "velocity": 0,
+    "rotation": 180.0
+  },
+  "useDefaultConstraints": false
+}

--- a/deploy/pathplanner/settings.json
+++ b/deploy/pathplanner/settings.json
@@ -4,8 +4,9 @@
   "holonomicMode": true,
   "pathFolders": [
     "Babies",
-    "Men",
     "Elders'",
+    "Men",
+    "Blind",
     "Toddlers"
   ],
   "autoFolders": [],

--- a/deploy/pathplanner/settings.json
+++ b/deploy/pathplanner/settings.json
@@ -15,7 +15,7 @@
   "defaultMaxAngVel": 720.0,
   "defaultMaxAngAccel": 1600.0,
   "defaultNominalVoltage": 12.0,
-  "robotMass": 68.0389,
+  "robotMass": 61.235,
   "robotMOI": 6.634,
   "robotTrackwidth": 0.546,
   "driveWheelRadius": 0.051,

--- a/generated/tuner_constants.py
+++ b/generated/tuner_constants.py
@@ -15,23 +15,23 @@ class TunerConstants:
     # output type specified by SwerveModuleConstants.SteerMotorClosedLoopOutput
     _steer_gains = (
         configs.Slot0Configs()
-        .with_k_p(100)
+        .with_k_p(50.891)
         .with_k_i(0)
-        .with_k_d(2.5)
-        .with_k_s(0.1)
-        .with_k_v(2.5811)
-        .with_k_a(0.067726)
+        .with_k_d(3.0703)
+        .with_k_s(0.26295)
+        .with_k_v(2.5787)
+        .with_k_a(0.068813)
         .with_static_feedforward_sign(signals.StaticFeedforwardSignValue.USE_CLOSED_LOOP_SIGN)
     )
     # When using closed-loop control, the drive motor uses the control
     # output type specified by SwerveModuleConstants.DriveMotorClosedLoopOutput
     _drive_gains = (
         configs.Slot0Configs()
-        .with_k_p(0.1)
+        .with_k_p(0.17238)
         .with_k_i(0)
         .with_k_d(0)
-        .with_k_s(0.18)
-        .with_k_v(0.124)
+        .with_k_s(0.19179)
+        .with_k_v(0.12549)
     )
 
     # The closed-loop output type to use for the steer motors;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,11 +4,14 @@ robotpy_version = "2025.3.1.1"
 
 robotpy_extras = [
     "apriltag",
-    "commands2"
+    "commands2",
+    "cscore"
 ]
 
 # Other pip packages to install
 requires = [
     "robotpy-pathplannerlib==2025.2.6",
-    "phoenix6==25.3.1"
+    "phoenix6==25.3.1",
+    "robotpy-opencv; platform_machine == 'roborio'",
+    "opencv-python; platform_machine != 'roborio'"
 ]

--- a/robot.py
+++ b/robot.py
@@ -3,7 +3,7 @@ import os.path
 from commands2 import CommandScheduler, TimedCommandRobot
 from ntcore import NetworkTableInstance
 from phoenix6 import SignalLogger
-from wpilib import DataLogManager, DriverStation, Timer
+from wpilib import DataLogManager, DriverStation, Timer, CameraServer
 from wpinet import WebServer, PortForwarder
 
 from constants import Constants
@@ -23,6 +23,8 @@ class Leviathan(TimedCommandRobot):
         SignalLogger.enable_auto_logging(DriverStation.isFMSAttached())
         DataLogManager.start(period=0.2)
         DriverStation.startDataLog(DataLogManager.getLog())
+
+        CameraServer.launch()
 
         WebServer.getInstance().start(5800, self.get_deploy_directory())
         port_forwarder = PortForwarder.getInstance()

--- a/subsystems/intake.py
+++ b/subsystems/intake.py
@@ -3,7 +3,7 @@ from enum import auto, Enum
 import commands2.cmd
 from commands2 import Command, cmd
 from phoenix6 import utils
-from phoenix6.configs import CANrangeConfiguration, TalonFXConfiguration, MotorOutputConfigs, FeedbackConfigs, HardwareLimitSwitchConfigs
+from phoenix6.configs import CANrangeConfiguration, TalonFXConfiguration, MotorOutputConfigs, FeedbackConfigs, HardwareLimitSwitchConfigs, ProximityParamsConfigs
 from phoenix6.controls import VelocityDutyCycle, DutyCycleOut
 from phoenix6.hardware import TalonFX, CANrange
 from phoenix6.signals import NeutralModeValue, ForwardLimitValue, ForwardLimitSourceValue
@@ -26,7 +26,7 @@ class IntakeSubsystem(StateSubsystem):
         ALGAE_OUTPUT = auto()
         L1_OUTPUT = auto()
 
-    _canrange_config = (CANrangeConfiguration())
+    _canrange_config = (CANrangeConfiguration().with_proximity_params(ProximityParamsConfigs().with_proximity_threshold(0.1)))
 
     _motor_config = (TalonFXConfiguration()
                      .with_slot0(Constants.IntakeConstants.GAINS)

--- a/subsystems/intake.py
+++ b/subsystems/intake.py
@@ -2,10 +2,11 @@ from enum import auto, Enum
 
 import commands2.cmd
 from commands2 import Command, cmd
-from phoenix6.configs import TalonFXConfiguration, MotorOutputConfigs, FeedbackConfigs
+from phoenix6 import utils
+from phoenix6.configs import CANrangeConfiguration, TalonFXConfiguration, MotorOutputConfigs, FeedbackConfigs, HardwareLimitSwitchConfigs
 from phoenix6.controls import VelocityDutyCycle, DutyCycleOut
-from phoenix6.hardware import TalonFX
-from phoenix6.signals import NeutralModeValue, ForwardLimitValue
+from phoenix6.hardware import TalonFX, CANrange
+from phoenix6.signals import NeutralModeValue, ForwardLimitValue, ForwardLimitSourceValue
 
 from constants import Constants
 from subsystems import StateSubsystem
@@ -25,11 +26,17 @@ class IntakeSubsystem(StateSubsystem):
         ALGAE_OUTPUT = auto()
         L1_OUTPUT = auto()
 
+    _canrange_config = (CANrangeConfiguration())
+
     _motor_config = (TalonFXConfiguration()
                      .with_slot0(Constants.IntakeConstants.GAINS)
                      .with_motor_output(MotorOutputConfigs().with_neutral_mode(NeutralModeValue.BRAKE))
                      .with_feedback(FeedbackConfigs().with_sensor_to_mechanism_ratio(Constants.ElevatorConstants.GEAR_RATIO))
                      )
+
+    _limit_switch_config = HardwareLimitSwitchConfigs()
+    _limit_switch_config.forward_limit_remote_sensor_id = Constants.CanIDs.INTAKE_CANRANGE
+    _limit_switch_config.forward_limit_source = ForwardLimitSourceValue.REMOTE_CANRANGE # Top Limit Switch
 
     _state_configs: dict[SubsystemState, tuple[int, bool]] = {
         SubsystemState.HOLD: (0, False),
@@ -45,7 +52,13 @@ class IntakeSubsystem(StateSubsystem):
         super().__init__("Intake", self.SubsystemState.HOLD)
 
         self._intake_motor = TalonFX(Constants.CanIDs.INTAKE_TALON)
+        _motor_config = self._motor_config
+        if not utils.is_simulation():
+            _motor_config.hardware_limit_switch = self._limit_switch_config
         self._intake_motor.configurator.apply(self._motor_config)
+
+        self._canrange = CANrange(Constants.CanIDs.INTAKE_CANRANGE)
+        self._canrange.configurator.apply(self._canrange_config)
 
         self._velocity_request = DutyCycleOut(0)
 

--- a/subsystems/superstructure.py
+++ b/subsystems/superstructure.py
@@ -38,20 +38,21 @@ class Superstructure(Subsystem):
             tuple[
                 Optional[PivotSubsystem.SubsystemState],
                 Optional[ElevatorSubsystem.SubsystemState],
-                Optional[FunnelSubsystem.SubsystemState]
+                Optional[FunnelSubsystem.SubsystemState],
+                Optional[VisionSubsystem.SubsystemState]
             ]] = {
-        Goal.DEFAULT: (PivotSubsystem.SubsystemState.STOW, ElevatorSubsystem.SubsystemState.DEFAULT, FunnelSubsystem.SubsystemState.DOWN),
-        Goal.L4_CORAL: (PivotSubsystem.SubsystemState.HIGH_SCORING, ElevatorSubsystem.SubsystemState.L4, FunnelSubsystem.SubsystemState.DOWN),
-        Goal.L3_CORAL: (PivotSubsystem.SubsystemState.L3_CORAL, ElevatorSubsystem.SubsystemState.L3, FunnelSubsystem.SubsystemState.DOWN),
-        Goal.L2_CORAL: (PivotSubsystem.SubsystemState.L2_CORAL, ElevatorSubsystem.SubsystemState.L2, FunnelSubsystem.SubsystemState.DOWN),
-        Goal.L1_CORAL: (PivotSubsystem.SubsystemState.LOW_SCORING, ElevatorSubsystem.SubsystemState.L1, FunnelSubsystem.SubsystemState.DOWN),
-        Goal.L2_ALGAE: (PivotSubsystem.SubsystemState.ALGAE_INTAKE, ElevatorSubsystem.SubsystemState.L2_ALGAE, FunnelSubsystem.SubsystemState.DOWN),
-        Goal.L3_ALGAE: (PivotSubsystem.SubsystemState.ALGAE_INTAKE, ElevatorSubsystem.SubsystemState.L3_ALGAE, FunnelSubsystem.SubsystemState.DOWN),
-        Goal.PROCESSOR: (PivotSubsystem.SubsystemState.PROCESSOR_SCORING, ElevatorSubsystem.SubsystemState.DEFAULT, FunnelSubsystem.SubsystemState.DOWN),
-        Goal.NET: (PivotSubsystem.SubsystemState.NET_SCORING, ElevatorSubsystem.SubsystemState.NET, FunnelSubsystem.SubsystemState.DOWN),
-        Goal.FUNNEL: (PivotSubsystem.SubsystemState.FUNNEL_INTAKE, ElevatorSubsystem.SubsystemState.DEFAULT, FunnelSubsystem.SubsystemState.UP),
-        Goal.FLOOR: (PivotSubsystem.SubsystemState.GROUND_INTAKE, ElevatorSubsystem.SubsystemState.DEFAULT, FunnelSubsystem.SubsystemState.DOWN),
-        Goal.CLIMBING: (PivotSubsystem.SubsystemState.AVOID_CLIMBER, ElevatorSubsystem.SubsystemState.DEFAULT, FunnelSubsystem.SubsystemState.DOWN)
+        Goal.DEFAULT: (PivotSubsystem.SubsystemState.STOW, ElevatorSubsystem.SubsystemState.DEFAULT, FunnelSubsystem.SubsystemState.DOWN, VisionSubsystem.SubsystemState.ALL_ESTIMATES),
+        Goal.L4_CORAL: (PivotSubsystem.SubsystemState.HIGH_SCORING, ElevatorSubsystem.SubsystemState.L4, FunnelSubsystem.SubsystemState.DOWN, VisionSubsystem.SubsystemState.REEF_ESTIMATES),
+        Goal.L3_CORAL: (PivotSubsystem.SubsystemState.L3_CORAL, ElevatorSubsystem.SubsystemState.L3, FunnelSubsystem.SubsystemState.DOWN, VisionSubsystem.SubsystemState.REEF_ESTIMATES),
+        Goal.L2_CORAL: (PivotSubsystem.SubsystemState.L2_CORAL, ElevatorSubsystem.SubsystemState.L2, FunnelSubsystem.SubsystemState.DOWN, VisionSubsystem.SubsystemState.REEF_ESTIMATES),
+        Goal.L1_CORAL: (PivotSubsystem.SubsystemState.LOW_SCORING, ElevatorSubsystem.SubsystemState.L1, FunnelSubsystem.SubsystemState.DOWN, VisionSubsystem.SubsystemState.REEF_ESTIMATES),
+        Goal.L2_ALGAE: (PivotSubsystem.SubsystemState.ALGAE_INTAKE, ElevatorSubsystem.SubsystemState.L2_ALGAE, FunnelSubsystem.SubsystemState.DOWN, VisionSubsystem.SubsystemState.REEF_ESTIMATES),
+        Goal.L3_ALGAE: (PivotSubsystem.SubsystemState.ALGAE_INTAKE, ElevatorSubsystem.SubsystemState.L3_ALGAE, FunnelSubsystem.SubsystemState.DOWN, VisionSubsystem.SubsystemState.REEF_ESTIMATES),
+        Goal.PROCESSOR: (PivotSubsystem.SubsystemState.PROCESSOR_SCORING, ElevatorSubsystem.SubsystemState.DEFAULT, FunnelSubsystem.SubsystemState.DOWN, VisionSubsystem.SubsystemState.ALL_ESTIMATES),
+        Goal.NET: (PivotSubsystem.SubsystemState.NET_SCORING, ElevatorSubsystem.SubsystemState.NET, FunnelSubsystem.SubsystemState.DOWN, VisionSubsystem.SubsystemState.ALL_ESTIMATES),
+        Goal.FUNNEL: (PivotSubsystem.SubsystemState.FUNNEL_INTAKE, ElevatorSubsystem.SubsystemState.DEFAULT, FunnelSubsystem.SubsystemState.UP, VisionSubsystem.SubsystemState.ALL_ESTIMATES),
+        Goal.FLOOR: (PivotSubsystem.SubsystemState.GROUND_INTAKE, ElevatorSubsystem.SubsystemState.DEFAULT, FunnelSubsystem.SubsystemState.DOWN, VisionSubsystem.SubsystemState.ALL_ESTIMATES),
+        Goal.CLIMBING: (PivotSubsystem.SubsystemState.AVOID_CLIMBER, ElevatorSubsystem.SubsystemState.DEFAULT, FunnelSubsystem.SubsystemState.DOWN, VisionSubsystem.SubsystemState.NO_ESTIMATES)
     }
         
     def __init__(self, drivetrain: SwerveSubsystem, pivot: PivotSubsystem, elevator: ElevatorSubsystem, funnel: FunnelSubsystem, vision: VisionSubsystem) -> None:
@@ -131,13 +132,15 @@ class Superstructure(Subsystem):
     def _set_goal(self, goal: Goal) -> None:
         self._goal = goal
 
-        pivot_state, elevator_state, funnel_state = self._goal_to_states.get(goal, (None, None, None))
+        pivot_state, elevator_state, funnel_state, vision_state = self._goal_to_states.get(goal, (None, None, None, None))
         if pivot_state:
             self.pivot.set_desired_state(pivot_state)
         if elevator_state:
             self.elevator.set_desired_state(elevator_state)
         if funnel_state:
             self.funnel.set_desired_state(funnel_state)
+        if vision_state:
+            self.vision.set_desired_state(vision_state)
 
         self._current_goal_pub.set(goal.name)
 

--- a/subsystems/swerve.py
+++ b/subsystems/swerve.py
@@ -268,7 +268,7 @@ class SwerveSubsystem(Subsystem, swerve.SwerveDrivetrain):
         See the documentation of swerve.requests.SysIdSwerveRotation for info on importing the log to SysId.
         """
 
-        self._sys_id_routine_to_apply = self._sys_id_routine_translation
+        self._sys_id_routine_to_apply = self._sys_id_routine_steer
         """The SysId routine to test"""
 
         if utils.is_simulation():

--- a/subsystems/vision.py
+++ b/subsystems/vision.py
@@ -103,11 +103,11 @@ class VisionSubsystem(StateSubsystem):
             LimelightHelpers.set_fiducial_id_filters_override(camera, desired_state.value)
 
     def _process_camera(self, camera: str) -> tuple[str, PoseEstimate | None]:
-        state = self._swerve.get_state_copy().pose.rotation()
+        state = self._swerve.get_state_copy()
         LimelightHelpers.set_robot_orientation(
             camera,
-            state.degrees(),
-            0, 0, 0, 0, 0
+            state.pose.rotation().degrees(),
+            state.speeds.omega_dps, 0, 0, 0, 0
         )
         pose = LimelightHelpers.get_botpose_estimate_wpiblue_megatag2(camera)
 

--- a/subsystems/vision.py
+++ b/subsystems/vision.py
@@ -1,6 +1,6 @@
 import concurrent.futures
 import math
-from enum import Enum, auto
+from enum import Enum
 
 from phoenix6 import utils
 
@@ -23,13 +23,13 @@ class VisionSubsystem(StateSubsystem):
     """
 
     class SubsystemState(Enum):
-        ALL_ESTIMATES = auto()
+        ALL_ESTIMATES = list(range(1,23))
         """ Enables MegaTag 2 pose estimates to the robot from all tags."""
 
-        REEF_ESTIMATES = auto()
+        REEF_ESTIMATES = [6, 7, 8, 9, 10, 11, 17, 18, 19, 20, 21, 22]
         """Only allows pose estimates from tags from the reef."""
 
-        NO_ESTIMATES = auto()
+        NO_ESTIMATES = []
         """ Ignores all Limelight pose estimates. """
 
     def __init__(self, swerve: SwerveSubsystem, *cameras: str):
@@ -70,6 +70,9 @@ class VisionSubsystem(StateSubsystem):
     def set_desired_state(self, desired_state: SubsystemState) -> None:
         if not super().set_desired_state(desired_state):
             return
+
+        for camera in self._cameras:
+            LimelightHelpers.set_fiducial_id_filters_override(camera, desired_state.value)
 
     def _process_camera(self, camera: str) -> PoseEstimate | None:
         """ Retrieves pose estimate for a single camera and ensures it's closer to expected than the last one. """

--- a/subsystems/vision.py
+++ b/subsystems/vision.py
@@ -23,14 +23,17 @@ class VisionSubsystem(StateSubsystem):
     """
 
     class SubsystemState(Enum):
-        ENABLE_ESTIMATES = auto()
-        """ Enables MegaTag 2 pose estimates to the robot."""
+        ALL_ESTIMATES = auto()
+        """ Enables MegaTag 2 pose estimates to the robot from all tags."""
 
-        DISABLE_ESTIMATES = auto()
+        REEF_ESTIMATES = auto()
+        """Only allows pose estimates from tags from the reef."""
+
+        NO_ESTIMATES = auto()
         """ Ignores all Limelight pose estimates. """
 
     def __init__(self, swerve: SwerveSubsystem, *cameras: str):
-        super().__init__("Vision", self.SubsystemState.ENABLE_ESTIMATES)
+        super().__init__("Vision", self.SubsystemState.ALL_ESTIMATES)
 
         self._swerve = swerve
         self._cameras = tuple(cameras)
@@ -44,10 +47,10 @@ class VisionSubsystem(StateSubsystem):
         super().periodic()
 
         state = self._subsystem_state
-        if state is self.SubsystemState.DISABLE_ESTIMATES:
+        if state is self.SubsystemState.NO_ESTIMATES:
             return
 
-        if abs(self._swerve.pigeon2.get_angular_velocity_z_world().value) > 720 or state == self.SubsystemState.DISABLE_ESTIMATES:
+        if abs(self._swerve.pigeon2.get_angular_velocity_z_world().value) > 720 or state == self.SubsystemState.NO_ESTIMATES:
             return
 
         futures = [

--- a/subsystems/vision.py
+++ b/subsystems/vision.py
@@ -26,7 +26,7 @@ class VisionSubsystem(StateSubsystem):
     """
 
     class SubsystemState(Enum):
-        ALL_ESTIMATES = list(range(1,23))
+        ALL_ESTIMATES = list(range(1, 23))
         """ Enables MegaTag 2 pose estimates to the robot from all tags."""
 
         REEF_ESTIMATES = [6, 7, 8, 9, 10, 11, 17, 18, 19, 20, 21, 22]

--- a/subsystems/vision.py
+++ b/subsystems/vision.py
@@ -69,7 +69,7 @@ class VisionSubsystem(StateSubsystem):
                 if best_estimate is None or self._is_better_estimate(estimate, best_estimate):
                     best_estimate = estimate
             except Exception as e:
-                DataLogManager.log(f"Vision processing failed for a camera: {e}")  # Replace with proper logging
+                DataLogManager.log(f"Vision processing failed for a camera: {e}")
 
         if best_estimate:
             self._swerve.add_vision_measurement(


### PR DESCRIPTION
- Instead of implementing each camera pose estimate, find which one has the lowest ambiguity and only add that measurement. This should reduce "pose jittering" when far away from an April Tag, such as the starting line in autonomous.
- Log visible tags for diagnostics
- When scoring in specific Superstructure goals, only trust estimates near the reef. This should reduce issues with poor field tolerances.